### PR TITLE
Url fix

### DIFF
--- a/src/Provider/Discord.php
+++ b/src/Provider/Discord.php
@@ -17,8 +17,8 @@ class Discord extends \League\OAuth2\Client\Provider\AbstractProvider
      * Base URL of the Discord API
      * @var string
      */
-    // protected $baseUrl = 'https://discordapp.com/api';
-    protected $baseUrl = 'https://discordapp.com';
+    protected $baseUrl = 'https://discordapp.com/api';
+    //protected $baseUrl = 'https://discordapp.com';
 
     /**
      * Default scopes to be requested


### PR DESCRIPTION
"https://discordapp.com" causes a HTTP 405 Error message.